### PR TITLE
Add medial surface mode

### DIFF
--- a/src/main/java/sc/fiji/skeletonize3D/MedialSurface3D_.java
+++ b/src/main/java/sc/fiji/skeletonize3D/MedialSurface3D_.java
@@ -1,0 +1,11 @@
+package sc.fiji.skeletonize3D;
+
+import ij.ImagePlus;
+
+public class MedialSurface3D_ extends Skeletonize3D_{
+	public int setup(String arg, ImagePlus imp) 
+	{
+		this.surfaceMode = true;
+		return super.setup(arg,imp);
+	} 
+}

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -8,3 +8,4 @@
 # Requires: ImageJ
 
 Plugins>Skeleton, "Skeletonize (2D/3D)", sc.fiji.skeletonize3D.Skeletonize3D_
+Plugins>Skeleton, "Get Medial Surface (3D)", sc.fiji.skeletonize3D.MedialSurface3D_


### PR DESCRIPTION
Adds a medial surface mode to the skeletonize code, following Definition 1 (with corrections) from Lee. This may be useful for representing 3D objects which are more planar than linear, although there is no equivalent of AnalyzeSkeleton for further analysis, and I don't know if there is sufficient interest to justify inclusion of this algorithm.

I also added rechecking of Euler invariance during serial deletion (standard and surface mode), since I was editing that section anyway. This may resolve issue #3 but will probably lead to changed results in general, with some reduction in deletions. In my surface test I got a very slight increase in surviving voxels after adding this rechecking.

I tested this as library code, since I have no experience building plugins. This is also my first PR, so hopefully I haven't messed it up too much.